### PR TITLE
🔗 Fix template links

### DIFF
--- a/frontmatter/volume.yml
+++ b/frontmatter/volume.yml
@@ -28,4 +28,4 @@ project:
     volume: 1
     doi: ...
 site:
-  template: article-theme
+  template: https://github.com/myst-templates/article-theme.git

--- a/papers/gottumukkala/myst.yml
+++ b/papers/gottumukkala/myst.yml
@@ -38,11 +38,3 @@ project:
         - Writing-original draft
 
   subject: Biology
-  venue: The Morganton Scientific
-  exports:
-    - format: typst
-      article: article.md
-      template: https://github.com/myst-templates/scipy.git
-site:
-  template: article-theme
-

--- a/papers/mikolajec/myst.yml
+++ b/papers/mikolajec/myst.yml
@@ -42,10 +42,3 @@ project:
     CS: Cassava starch
 
   subject: Chemistry
-  venue: The Morganton Scientific
-  exports:
-    - format: typst
-      article: article.md
-      template: https://github.com/myst-templates/scipy.git
-site:
-  template: article-theme

--- a/papers/morganton2025.yml
+++ b/papers/morganton2025.yml
@@ -4,7 +4,7 @@ project:
   exports:
     - id: typst-export
       format: typst
-      template: ../../templates/ncssm
+      template: https://github.com/curvenote-templates/ncssm.git
       article: article.md
       output: article.pdf
   downloads:

--- a/papers/urmanova2/myst.yml
+++ b/papers/urmanova2/myst.yml
@@ -41,10 +41,3 @@ project:
     tDCS: Transcranial direct current stimulation
     TMS: Transcranial magnetic stimulation
   subject: Biology
-  venue: The Morganton Scientific
-  exports:
-    - format: typst
-      article: article.md
-      template: https://github.com/myst-templates/scipy.git
-site:
-  template: article-theme

--- a/papers/zhu/myst.yml
+++ b/papers/zhu/myst.yml
@@ -26,10 +26,3 @@ project:
         - Visualization
         - Writing-original draft
   subject: Biology
-  venue: The Morganton Scientific
-  exports:
-    - format: typst
-      article: article.md
-      template: https://github.com/myst-templates/scipy.git
-site:
-  template: article-theme


### PR DESCRIPTION
This updates the typst template to point to a github repo rather than a nonexistent folder. It also updates the site template to point directly to github, eliminating an extra lookup step that previously caused some failures.