### PR TITLE
📕 Update scripts, frontmatter, preface theme for volume pdf generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ _build
 .ipynb_checkpoints
 *.bak
 .DS_Store
+
+article.pdf
+morganton2025.pdf

--- a/essays/nair/myst.yml
+++ b/essays/nair/myst.yml
@@ -17,8 +17,8 @@ project:
       affiliation: NCSSM
       roles:
         - Writing original draft
-  first_page: 0
-  last_page: 0
+  first_page: 19
+  last_page: 21
   abbreviations:
     HIV: Human Immunodeficiency Virus
     CRISPR: Clustered Regularly Interspaced Short Palindromic Repeats

--- a/essays/nair/myst.yml
+++ b/essays/nair/myst.yml
@@ -17,6 +17,8 @@ project:
       affiliation: NCSSM
       roles:
         - Writing original draft
+  first_page: 0
+  last_page: 0
   abbreviations:
     HIV: Human Immunodeficiency Virus
     CRISPR: Clustered Regularly Interspaced Short Palindromic Repeats

--- a/essays/urmanova2/myst.yml
+++ b/essays/urmanova2/myst.yml
@@ -31,6 +31,8 @@ project:
         - Validation
         - Visualization
         - Writing-original draft
+  first_page: 0
+  last_page: 0
   abbreviations:
     ED: Eating disorders
     BED: Binge-eating disorder

--- a/essays/urmanova2/myst.yml
+++ b/essays/urmanova2/myst.yml
@@ -31,8 +31,8 @@ project:
         - Validation
         - Visualization
         - Writing-original draft
-  first_page: 0
-  last_page: 0
+  first_page: 22
+  last_page: 28
   abbreviations:
     ED: Eating disorders
     BED: Binge-eating disorder

--- a/frontmatter/volume.yml
+++ b/frontmatter/volume.yml
@@ -9,7 +9,7 @@ project:
   venue:
     title: Morganton Scientific
     url: https://morgantonscientific.ncssm.edu
-    doi: ...
+    doi: 10.62329/TJYM8050
   abbreviations:
     NCSSM: North Carolina School of Science and Mathematics
   funding:
@@ -24,8 +24,8 @@ project:
       postal_code: 28655
       phone: 828-347-9100
       ror: https://ror.org/03zbydc22
-  biblio:
-    volume: 1
+  volume:
+    number: 1
     doi: ...
 site:
   template: https://github.com/myst-templates/article-theme.git

--- a/interviews/cummings_interview/myst.yml
+++ b/interviews/cummings_interview/myst.yml
@@ -13,6 +13,8 @@ project:
     - Hospital neurology
     - Healthcare
   subject: Interview
+  first_page: 0
+  last_page: 0
   abbreviations:
     DBS: Deep brain stimulation
     EEG: Electroencephalogram

--- a/interviews/moore_interview/myst.yml
+++ b/interviews/moore_interview/myst.yml
@@ -17,8 +17,8 @@ project:
     - Neurologist
     - Motor Disorders
   subject: Interview
-  first_page: 0
-  last_page: 0
+  first_page: 5
+  last_page: 18
   abbreviations:
     DBS: Deep brain stimulation
     EEG: Electroencephalogram

--- a/interviews/moore_interview/myst.yml
+++ b/interviews/moore_interview/myst.yml
@@ -17,6 +17,8 @@ project:
     - Neurologist
     - Motor Disorders
   subject: Interview
+  first_page: 0
+  last_page: 0
   abbreviations:
     DBS: Deep brain stimulation
     EEG: Electroencephalogram

--- a/papers/allred/myst.yml
+++ b/papers/allred/myst.yml
@@ -25,6 +25,8 @@ project:
         - Methodology
         - Writing - Original Draft
         - Writing - Review & Editing
+  first_page: 5
+  last_page: 9
   abbreviations:
     PET: polyethylene terephthalate
     TPA: terephthalic acid

--- a/papers/allred/myst.yml
+++ b/papers/allred/myst.yml
@@ -25,8 +25,8 @@ project:
         - Methodology
         - Writing - Original Draft
         - Writing - Review & Editing
-  first_page: 5
-  last_page: 9
+  first_page: 29
+  last_page: 33
   abbreviations:
     PET: polyethylene terephthalate
     TPA: terephthalic acid

--- a/papers/bansal/myst.yml
+++ b/papers/bansal/myst.yml
@@ -26,6 +26,8 @@ project:
         - Validation
         - Visualization
         - Writing-original draft
+  first_page: 10
+  last_page: 15
   abbreviations:
     CSA: Childhood sexual assault
     PTSD: Post-traumatic stress disorder

--- a/papers/bansal/myst.yml
+++ b/papers/bansal/myst.yml
@@ -26,8 +26,8 @@ project:
         - Validation
         - Visualization
         - Writing-original draft
-  first_page: 10
-  last_page: 15
+  first_page: 34
+  last_page: 39
   abbreviations:
     CSA: Childhood sexual assault
     PTSD: Post-traumatic stress disorder

--- a/papers/chintapalli/myst.yml
+++ b/papers/chintapalli/myst.yml
@@ -26,8 +26,8 @@ project:
         - Visualization
         - writing
         - editing
-  first_page: 16
-  last_page: 28
+  first_page: 40
+  last_page: 52
   abbreviations:
     BRFSS: Behavioral Risk Factor Surveillance System
     FPMH: Frequent Poor Mental Health

--- a/papers/chintapalli/myst.yml
+++ b/papers/chintapalli/myst.yml
@@ -26,6 +26,8 @@ project:
         - Visualization
         - writing
         - editing
+  first_page: 16
+  last_page: 28
   abbreviations:
     BRFSS: Behavioral Risk Factor Surveillance System
     FPMH: Frequent Poor Mental Health

--- a/papers/edwin/myst.yml
+++ b/papers/edwin/myst.yml
@@ -19,6 +19,8 @@ project:
       roles:
         - Conceptualization
         - Writing-original draft
+  first_page: 0
+  last_page: 0
   abbreviations:
     CAR: chimeric antigen receptor
     ALL: acute lymphoblastic leukemia

--- a/papers/gencel/myst.yml
+++ b/papers/gencel/myst.yml
@@ -25,6 +25,8 @@ project:
         - Validation
         - Visualization
         - Writing
+  first_page: 0
+  last_page: 0
   abbreviations:
     NCSSM: North Carolina School of Science and Mathematics
     DFT: Density functional theory

--- a/papers/goel/myst.yml
+++ b/papers/goel/myst.yml
@@ -27,6 +27,8 @@ project:
         - Validation
         - Visualization
         - Writing-original draft
+  first_page: 0
+  last_page: 0
   abbreviations:
     K: Equilibrium Constant
     DFT: Density Functional Theory

--- a/papers/gottumukkala/myst.yml
+++ b/papers/gottumukkala/myst.yml
@@ -26,5 +26,6 @@ project:
         - Validation
         - Visualization
         - Writing-original draft
-
+  first_page: 0
+  last_page: 0
   subject: Biology

--- a/papers/kitchell/myst.yml
+++ b/papers/kitchell/myst.yml
@@ -27,6 +27,8 @@ project:
         - Visualization
         - Writing - Original Draft
         - Writing - Review & Editing
+  first_page: 0
+  last_page: 0
   abbreviations:
     PET: Polyethylene terephthalate
     TPA: Terephthalic acid

--- a/papers/kulla/myst.yml
+++ b/papers/kulla/myst.yml
@@ -26,8 +26,8 @@ project:
         - Validation
         - Visualization
         - Writing original draft
-  first_page: 29
-  last_page: 44
+  first_page: 53
+  last_page: 68
   abbreviations:
     FTIR: Fourier Transform Infrared Spectroscopy
     ABTS: 2,2'-azino-bis(3-ethylbenzothiazoline-6-sulfonic acid Colorimetric Assay

--- a/papers/kulla/myst.yml
+++ b/papers/kulla/myst.yml
@@ -26,6 +26,8 @@ project:
         - Validation
         - Visualization
         - Writing original draft
+  first_page: 29
+  last_page: 44
   abbreviations:
     FTIR: Fourier Transform Infrared Spectroscopy
     ABTS: 2,2'-azino-bis(3-ethylbenzothiazoline-6-sulfonic acid Colorimetric Assay

--- a/papers/li/myst.yml
+++ b/papers/li/myst.yml
@@ -28,6 +28,8 @@ project:
         - Visualization
         - Writing - Original Draft
         - Writing - Review & Editing
+  first_page: 0
+  last_page: 0
   abbreviations:
     NCSSM: North Carolina School of Science and Mathematics
     GPCR: G-Protein-Coupled Receptor

--- a/papers/mikolajec/myst.yml
+++ b/papers/mikolajec/myst.yml
@@ -26,6 +26,8 @@ project:
         - Validation
         - Visualization
         - Writing-original draft
+  first_page: 0
+  last_page: 0
   abbreviations:
     LNR: Latex natural rubber
     CSG: Corn starch and glycerol

--- a/papers/ramidi/myst.yml
+++ b/papers/ramidi/myst.yml
@@ -30,5 +30,7 @@ project:
         - Investigation
         - Methodology
         - Writing
+  first_page: 0
+  last_page: 0
   abbreviations:
     PV: Photovoltaic

--- a/papers/sarkar/myst.yml
+++ b/papers/sarkar/myst.yml
@@ -25,8 +25,8 @@ project:
         - Methodology
         - Visualization
         - Writing-original draft
-  first_page: 45
-  last_page: 57
+  first_page: 69
+  last_page: 81
   abbreviations:
     PD: Parkinson's disease
     YFP: Yellow fluorescent protein

--- a/papers/sarkar/myst.yml
+++ b/papers/sarkar/myst.yml
@@ -25,6 +25,8 @@ project:
         - Methodology
         - Visualization
         - Writing-original draft
+  first_page: 45
+  last_page: 57
   abbreviations:
     PD: Parkinson's disease
     YFP: Yellow fluorescent protein

--- a/papers/sriram/myst.yml
+++ b/papers/sriram/myst.yml
@@ -27,6 +27,8 @@ project:
         - Visualization
         - Writing - Original Draft
         - Writing - Review & Editing
+  first_page: 58
+  last_page: 69
   abbreviations:
     AC: Alternating current
     DC: Direct current

--- a/papers/sriram/myst.yml
+++ b/papers/sriram/myst.yml
@@ -27,8 +27,8 @@ project:
         - Visualization
         - Writing - Original Draft
         - Writing - Review & Editing
-  first_page: 58
-  last_page: 69
+  first_page: 82
+  last_page: 93
   abbreviations:
     AC: Alternating current
     DC: Direct current

--- a/papers/urmanova/myst.yml
+++ b/papers/urmanova/myst.yml
@@ -23,6 +23,8 @@ project:
         - Investigation
         - Data curation
         - Visualization
+  first_page: 0
+  last_page: 0
   abbreviations:
     PD: Parkinson's Disease
     C. elegans: Caenorhabditis elegans

--- a/papers/zhu/myst.yml
+++ b/papers/zhu/myst.yml
@@ -25,4 +25,6 @@ project:
         - Validation
         - Visualization
         - Writing-original draft
+  first_page: 70
+  last_page: 78
   subject: Biology

--- a/papers/zhu/myst.yml
+++ b/papers/zhu/myst.yml
@@ -25,6 +25,6 @@ project:
         - Validation
         - Visualization
         - Writing-original draft
-  first_page: 70
-  last_page: 78
+  first_page: 94
+  last_page: 102
   subject: Biology

--- a/scripts/generate_summary.sh
+++ b/scripts/generate_summary.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# Usage: ./generate_summary.sh <output_file> <directory_path_1> <directory_path_2> ... <directory_path_n>
+
+OUTPUT_FILE=$1
+shift 1         # Shift to remove the first argument, leaving the base directories
+
+# Initialize the summary output file
+echo "- title: Words from the Editors" > "$OUTPUT_FILE"
+echo "  page: 4" >> "$OUTPUT_FILE"
+
+# Iterate over all provided base directories
+for BASE_DIR in "$@"; do
+    # Check if the base directory exists
+    if [ ! -d "$BASE_DIR" ]; then
+        echo "Base directory '$BASE_DIR' not found. Skipping."
+        continue
+    fi
+
+    echo "Processing base directory: $BASE_DIR"
+
+    # Iterate over all subdirectories in the base directory
+    for folder in "$BASE_DIR"/; do
+        yaml_file="${folder}myst.yml"
+
+        # Check if the YAML file exists in the current folder
+        if [ ! -f "$yaml_file" ]; then
+            echo "YAML file '$yaml_file' not found in folder '$folder'. Skipping."
+            continue
+        fi
+
+        # Extract relevant fields from YAML
+        title=$(grep "^ *title:" "$yaml_file" | sed "s/^ *title: //")
+        author_names=$(sed -n '/^  authors:/,/^  [a-z]/p' "$yaml_file" | awk '/^ *- name:/ {$1=$2=""; print $0 ", "}' | xargs | sed 's/, *$//')
+        first_page=$(grep "^ *first_page:" "$yaml_file" | sed "s/^ *first_page: //")
+
+        # Write to the summary file in the required format
+        echo "- title: $title" >> "$OUTPUT_FILE"
+        if [ ! -z "$author_names" ]; then
+            echo "  author: $author_names" >> "$OUTPUT_FILE"
+        fi
+        if [ ! -z "$first_page" ]; then
+            echo "  page: $first_page" >> "$OUTPUT_FILE"
+        else
+            echo "  page: 0" >> "$OUTPUT_FILE"
+        fi
+    done
+done
+
+echo "Summary file '$OUTPUT_FILE' generated successfully!"
+

--- a/scripts/make_pdfs.sh
+++ b/scripts/make_pdfs.sh
@@ -1,22 +1,22 @@
 # Generate article PDFs with maybe wrong page numbers
-for folder in $(ls ../papers | egrep -i '^[a-z-]+$' ); do
- cd ../papers/$folder
+for folder in $( ls -d -1 ../interviews/* ../essays/* ../papers/* ); do
+ cd $folder
  myst build --pdf
  cd ../../scripts
 done
 # Update page numbers in article myst.ymls
-bash ./update_pages.sh 5 ../papers/*
+bash ./update_pages.sh 5 ../interviews/* ../essays/* ../papers/*
 # Re-generate PDFs with correct page numbers
-for folder in $(ls ../papers | egrep -i '^[a-z-]+$' ); do
- cd ../papers/$folder
+for folder in $( ls -d -1 ../interviews/* ../essays/* ../papers/* ); do
+ cd $folder
  myst build --pdf
  cd ../../scripts
 done
 # Write frontmatter page number summary
-bash ./generate_summary.sh ../templates/ncssm-preface/papers.yml ../papers/*
+bash ./generate_summary.sh ../templates/ncssm-preface/papers.yml ../interviews/* ../essays/* ../papers/*
 # Generate frontmatter PDF
 cd ../frontmatter
 myst build --pdf
 cd ../
 # Combine all PDFs into final PDF
-pdftk frontmatter/article.pdf papers/*/article.pdf cat output morganton2025.pdf
+pdftk frontmatter/article.pdf interviews/*/article.pdf essays/*/article.pdf papers/*/article.pdf cat output morganton2025.pdf

--- a/scripts/make_pdfs.sh
+++ b/scripts/make_pdfs.sh
@@ -1,0 +1,22 @@
+# Generate article PDFs with maybe wrong page numbers
+for folder in $(ls ../papers | egrep -i '^[a-z-]+$' ); do
+ cd ../papers/$folder
+ myst build --pdf
+ cd ../../scripts
+done
+# Update page numbers in article myst.ymls
+bash ./update_pages.sh 5 ../papers/*
+# Re-generate PDFs with correct page numbers
+for folder in $(ls ../papers | egrep -i '^[a-z-]+$' ); do
+ cd ../papers/$folder
+ myst build --pdf
+ cd ../../scripts
+done
+# Write frontmatter page number summary
+bash ./generate_summary.sh ../templates/ncssm-preface/papers.yml ../papers/*
+# Generate frontmatter PDF
+cd ../frontmatter
+myst build --pdf
+cd ../
+# Combine all PDFs into final PDF
+pdftk frontmatter/article.pdf papers/*/article.pdf cat output morganton2025.pdf

--- a/scripts/update_pages.sh
+++ b/scripts/update_pages.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+# Check for required commands
+if ! command -v pdftk &> /dev/null; then
+    echo "Error: 'pdftk' is required but it's not installed."
+    exit 1
+fi
+
+# Usage: ./update_pages.sh <start_page> <directory_path_1> <directory_path_2> ... <directory_path_n>
+
+current_page=$1  # First argument is the start page
+shift            # Shift to remove the first argument, so now $@ contains the list of directories
+
+# Iterate over all provided base directories
+for BASE_DIR in "$@"; do
+    # Check if the base directory exists
+    if [ ! -d "$BASE_DIR" ]; then
+        echo "Base directory '$BASE_DIR' not found. Skipping."
+        continue
+    fi
+
+    echo "Processing base directory: $BASE_DIR"
+
+    # Iterate over all subdirectories in the base directory
+    for folder in "$BASE_DIR"/; do
+        yaml_file="${folder}myst.yml"
+
+        # Check if the YAML file exists in the current folder
+        if [ ! -f "$yaml_file" ]; then
+            echo "YAML file '$yaml_file' not found in folder '$folder'. Skipping."
+            continue
+        fi
+
+        # Find PDF files in the current folder
+        pdf_files=("$folder"*.pdf)
+
+        # Check if there are no PDFs or multiple PDFs
+        if [ ${#pdf_files[@]} -eq 0 ]; then
+            echo "No PDF files found in folder '$folder'. Skipping."
+            continue
+        elif [ ${#pdf_files[@]} -gt 1 ]; then
+            echo "Error: Multiple PDF files found in folder '$folder'. Only one PDF is allowed. Skipping."
+            continue
+        fi
+
+        # Get the single PDF file
+        pdf_file="${pdf_files[0]}"
+
+        # Get the number of pages in the PDF using pdftk
+        num_pages=$(pdftk "$pdf_file" dump_data | grep NumberOfPages | awk '{print $2}')
+        
+        if [ -z "$num_pages" ]; then
+            echo "Error counting pages in $pdf_file."
+            continue
+        fi
+
+        # Calculate first and last page
+        first_page=$current_page
+        last_page=$((current_page + num_pages - 1))
+        current_page=$((current_page + num_pages))
+
+        # Update first_page and last_page if they exist in the YAML
+        echo "Processing $pdf_file in $yaml_file: first_page=$first_page, last_page=$last_page"
+
+        # Update first_page only if it exists
+        if grep -q "first_page:" "$yaml_file"; then
+            sed -i.bak "s/first_page: [0-9]*/first_page: $first_page/" "$yaml_file"
+        fi
+
+        # Update last_page only if it exists
+        if grep -q "last_page:" "$yaml_file"; then
+            sed -i.bak "s/last_page: [0-9]*/last_page: $last_page/" $yaml_file
+        fi
+
+        echo "YAML file '$yaml_file' in folder '$folder' updated successfully!"
+    done
+done
+

--- a/templates/ncssm-preface/papers.yml
+++ b/templates/ncssm-preface/papers.yml
@@ -1,38 +1,50 @@
 - title: Words from the Editors
   page: 4
-- title: Analyzing Carbon-13 NMR Spectra to Predict Chemical Shifts of Carbon Compounds using Machine Learning Algorithms
-  author: Pranav Agrawala
+- title: An Examination of the Enzymatic Degradation of PET Plastic via PETase and MHETase
+  author: Ruby Allred
   page: 5
-- title: Decoding the Diet of a Local Owl Population
-  author: Sudiksha Battineni, Sophia Solomon, Meghan Leonard, Lauren Yu, Emily Brissenden
+- title: The Psychological Profile of a Future Abuser
+  author: Navya Bansal
   page: 10
-- title: Age Determination of NGC 1952 and PSR B0531+21 Using Radio Observations
-  author: Sydney Covington
-  page: 15
-- title: Using Bromelain Application to Inhibit the Spread of the Tobacco Mosaic Virus and Promote Tissue Regeneration in Red Bell Pepper Plants
-  author: Chisom Duru
-  page: 19
-- title: A Novel Approach to Inhibit MAP2K1 Overexpression Present in Melorheostosis Utilizing Moringa oleifera Extracts
-  author: Ashmith Gududuru
-  page: 24
-- title: Inhibition of TORC1 Pathway in Saccharomyces Cerevisiae to Induce Autophagy Using Graphene Oxide
-  author: Sesha Jonnavithula
-  page: 30
-- title: Assessing the Impact of Water, Algae, Alcohol, and Oil-Based Inks on the Biodegradability of Cellulose in Filter Paper
-  author: Prerana Kulla, Sophia Tang
-  page: 35
-- title: An Investigation of the Economics Behind Air Emergency Medical Services
-  author: Noah Langbo
-  page: 40
-- title: Predicting Network Traffic Flow with a Multi-Layer Short-Term Memory Model
-  author: Taran Puvvala
-  page: 44
-- title: 'AQINet: A multimodal deep convolutional neural network to predict Air Quality Index via satellite imagery and meteorological data'
-  author: Zoaib Sihorwala
-  page: 51
-- title: 'An Analysis on Genomic Correlation for Gallstone Susceptibility'
-  author: Sanjita Srinath
-  page: 56
-- title: 'Effect of Sulfakinin/Cholecystokinin-type Peptide ArSK/CCK1 on Satiety and Energy Metabolism of Asterias vulgaris'
-  author: Caroline Zhang
-  page: 64
+- title: Risk Factors of Frequent Poor Mental Health Days Among Adults in the United States
+  author: Anil Chintapalli
+  page: 16
+- title: Exploring the Use of Immunotherapy Techniques in Lymphocytic Leukemia
+  author: Enoch Edwin
+  page: 0
+- title: In Silico Exploration of L-Valine Ester Prodrug Designs for Enhanced Pharmacokinetics in BCS Class IV Nucleoside Antivirals.
+  author: Kevin Gencel
+  page: 0
+- title: Modeling Shifts in Reversible Chemical Reactions and Economic Markets
+  author: Radhika Goel
+  page: 0
+- title: Evaluating the Effects of Lactic Acid Fermented Foods on Type 2 Diabetes Mellitus using Bombyx mori Silkworms
+  author: Vivek Gottumukkala
+  page: 0
+- title: Utilizing Alkaline Hydrolysis to Recover Terephthalic Acid Monomer From PET-Based Textile Waste
+  author: Sarrah Kitchell
+  page: 0
+- title: Utilizing Enzymatic and Chemical Delignification Methods on Fibrous Plants for Decentralized Production of Absorbent Materials for Menstrual Pads in Semi-Arid Regions
+  author: Prerana Kulla
+  page: 29
+- title: Binding Affinity and Selectivity of Peptide Ligands for G-Protein-Coupled Receptors
+  author: Lily Li
+  page: 0
+- title: Green synthesis of decomposing rubber; comparing processing using carboxymethyl cellulose and Ipomoea pes-caprae
+  author: Zuzanna A. Mikolajec
+  page: 0
+- title: Optimizing Photovoltaic Output Through the Integration of Passive Optical Tools for Enhanced Photon Capture in Solar Cells
+  author: Prahas Ramidi, Akhilesh Karthik
+  page: 0
+- title: Evaluating the Effect of an Externally Applied Electric Field on Fluorescing Alpha-Synuclein Aggregates in NL5901 Parkinson's Disease Model of Caenorhabditis elegans
+  author: Adrija Sarkar
+  page: 45
+- title: Harvesting Energy with Affordable Piezoelectric Sensors for Low-Power Biosensors
+  author: Ananya Sriram
+  page: 58
+- title: Exploring The Gut-Brain Axis in C. elegans— Probiotics as a Therapeutic Approach to Alpha-Synuclein Aggregation in Parkinson’s Disease
+  author: Leyla Urmanova
+  page: 0
+- title: Computationally Modeling Factors of Aging that Affect the Population of T-cells and B-cells of Humans Age 60 and Older
+  author: Felice Zhu
+  page: 70

--- a/templates/ncssm-preface/papers.yml
+++ b/templates/ncssm-preface/papers.yml
@@ -1,14 +1,24 @@
 - title: Words from the Editors
   page: 4
+- title: An Interview with Mrs. Erika Cummings (PA) from the Duke Neurology Department on Clinical Neuroscience
+  page: 0
+- title: An Interview with Dr. Kathryn Moore (MD) from the Duke Neurology Department on Clinical Neuroscience and Research
+  page: 5
+- title: Designer Babies A Tale of Horrific Immoralities
+  author: Ganga Nair
+  page: 19
+- title: 'Rewiring Eating Disorder Recovery: Neuroethical Implications of tDCS in ED Treatment'
+  author: Leyla Urmanova
+  page: 22
 - title: An Examination of the Enzymatic Degradation of PET Plastic via PETase and MHETase
   author: Ruby Allred
-  page: 5
+  page: 29
 - title: The Psychological Profile of a Future Abuser
   author: Navya Bansal
-  page: 10
+  page: 34
 - title: Risk Factors of Frequent Poor Mental Health Days Among Adults in the United States
   author: Anil Chintapalli
-  page: 16
+  page: 40
 - title: Exploring the Use of Immunotherapy Techniques in Lymphocytic Leukemia
   author: Enoch Edwin
   page: 0
@@ -26,7 +36,7 @@
   page: 0
 - title: Utilizing Enzymatic and Chemical Delignification Methods on Fibrous Plants for Decentralized Production of Absorbent Materials for Menstrual Pads in Semi-Arid Regions
   author: Prerana Kulla
-  page: 29
+  page: 53
 - title: Binding Affinity and Selectivity of Peptide Ligands for G-Protein-Coupled Receptors
   author: Lily Li
   page: 0
@@ -38,13 +48,13 @@
   page: 0
 - title: Evaluating the Effect of an Externally Applied Electric Field on Fluorescing Alpha-Synuclein Aggregates in NL5901 Parkinson's Disease Model of Caenorhabditis elegans
   author: Adrija Sarkar
-  page: 45
+  page: 69
 - title: Harvesting Energy with Affordable Piezoelectric Sensors for Low-Power Biosensors
   author: Ananya Sriram
-  page: 58
+  page: 82
 - title: Exploring The Gut-Brain Axis in C. elegans— Probiotics as a Therapeutic Approach to Alpha-Synuclein Aggregation in Parkinson’s Disease
   author: Leyla Urmanova
   page: 0
 - title: Computationally Modeling Factors of Aging that Affect the Population of T-cells and B-cells of Humans Age 60 and Older
   author: Felice Zhu
-  page: 70
+  page: 94

--- a/templates/ncssm-preface/template.typ
+++ b/templates/ncssm-preface/template.typ
@@ -1,4 +1,3 @@
-#import "myst.typ": *
 #set text(font: "Noto Sans", size: 10pt)
 
 #let spacer = text(fill: gray)[ #h(8pt) | #h(8pt)]
@@ -17,9 +16,9 @@
 #align(center)[
   #grid(
     columns: (1fr, 1fr, 1fr),
-    align(left, text(font: "Noto Serif", fill: white, size: 20pt)[2024]),
+    align(left, text(font: "Noto Serif", fill: white, size: 20pt)[2025]),
     [],
-    align(right, text(font: "Noto Serif", fill: white, size: 20pt)[Volume 1])
+    align(right, text(font: "Noto Serif", fill: white, size: 20pt)[Volume 2])
   )
   #v(2em)
   #text(size:85pt, fill: white, font: "Noto Serif")[MORGANTON] \
@@ -39,8 +38,8 @@
     width: 100%,
     stroke: (top: 1pt + gray),
     inset: (top: 8pt, right: 2pt),
-    [
-      Morganton Scientific | Volume 1 | 2023 - 2024
+    context [
+      Morganton Scientific | Volume 2 | 2024 - 2025
       #h(1fr)
       #counter(page).display()
     ]
@@ -58,7 +57,7 @@
   #v(0.3em)
   #text(size:10pt)[Journal of Student STEM Research]
   #v(0.5em)
-  #text(size:10pt, fill: black.lighten(40%), link("https://doi.org/[-doc.biblio.doi-]")[https://doi.org/[-doc.biblio.doi-]])
+  #text(size:10pt, fill: black.lighten(40%), link("https://doi.org/[-doc.volume.doi-]")[https://doi.org/[-doc.volume.doi-]])
   #v(5em)
   #text(size:8pt, fill: black.lighten(40%), [Cover image by #link("https://www.freepik.com/free-photo/dna-genetic-biotechnology-science-gray-neon-graphic_26679196.htm")[Freepik]])
 ]

--- a/templates/ncssm-preface/template.yml
+++ b/templates/ncssm-preface/template.yml
@@ -30,5 +30,5 @@ parts:
     description: The forward to the journal volume
     required: true
 doc:
-  - id: biblio
+  - id: volume
     required: true


### PR DESCRIPTION
This pulls in some of the scripts from last year to build the full volume PDF. From the `scripts/` directory just run:

```
bash make_pdfs.sh
```

 This will build all the paper PDFs as well as construct the full volume PDF. Doing this uncovers which PDFs are not building, if you look in the auto-generated `pages.yml`

I also made a few tweaks to the preface theme to make it work.